### PR TITLE
筛选标签为“IYUU自动辅种”+状态为"paused"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@
 - `QB_PASSWD`: qBittorrent Web UI 的密码
 - `QB_BACKUP_PATH`: qBittorrent 种子备份路径 (默认: `%LOCALAPPDATA%\qBittorrent\BT_backup`)
 
+Tips: 也支持建立一个 `.env` 文件来设置以上环境变量，参照 `env.example` 文件。
+
 随后，在设置好的环境中运行 `main.py` 即可：
 
 ```bash

--- a/env.example
+++ b/env.example
@@ -1,0 +1,5 @@
+QB_HOST='http://127.0.0.1'
+QB_PORT=8080
+QB_USERNAME='admin'
+QB_PASSWD='admin'
+QB_BACKUP_PATH='%LOCALAPPDATA%\qBittorrent\BT_backup'

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ qb_host = str(getenv("QB_HOST", "http://127.0.0.1"))
 qb_port = int(getenv("QB_PORT", 8080))
 qb_username = str(getenv("QB_USERNAME", ""))
 qb_passwd = str(getenv("QB_PASSWD", ""))
-qb_backup_path = str(getenv("QB_BACKUP_PATH", os.path.join(expandvars("%LOCALAPPDATA%"), "qBittorrent\BT_backup")))
+qb_backup_path = str(expandvars(getenv("QB_BACKUP_PATH", r"%LOCALAPPDATA%\qBittorrent\BT_backup")))
 
 
 def qb_login(host: str, port: int, username: str, password: str) -> qbittorrentapi.Client:

--- a/main.py
+++ b/main.py
@@ -5,10 +5,13 @@ import time
 from os import getenv, mkdir
 from os.path import expandvars
 
+import dotenv
 import qbittorrentapi
 from packaging.version import Version
 
 from utils.avalon import Avalon
+
+dotenv.load_dotenv()
 
 qb_host = str(getenv("QB_HOST", "http://127.0.0.1"))
 qb_port = int(getenv("QB_PORT", 8080))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-colorama==0.4.6
-packaging==24.2
-qbittorrent_api==2024.9.67
-Requests==2.32.3
+colorama~=0.4.6
+packaging~=24.2
+qbittorrent_api~=2024.9.67
+Requests~=2.32.3
+python-dotenv~=1.1.0

--- a/torrent_move.py
+++ b/torrent_move.py
@@ -8,10 +8,13 @@ from os import getenv, mkdir
 from os.path import expandvars
 from tkinter import ttk
 
+import dotenv
 import qbittorrentapi
 from packaging.version import Version
 
 from utils.avalon import Avalon
+
+dotenv.load_dotenv()
 
 qb_host = str(getenv("QB_HOST", "http://127.0.0.1"))
 qb_port = int(getenv("QB_PORT", 8080))

--- a/torrent_move.py
+++ b/torrent_move.py
@@ -20,7 +20,7 @@ qb_host = str(getenv("QB_HOST", "http://127.0.0.1"))
 qb_port = int(getenv("QB_PORT", 8080))
 qb_username = str(getenv("QB_USERNAME", ""))
 qb_passwd = str(getenv("QB_PASSWD", ""))
-qb_backup_path = str(getenv("QB_BACKUP_PATH", os.path.join(expandvars("%LOCALAPPDATA%"), "qBittorrent\BT_backup")))
+qb_backup_path = str(expandvars(getenv("QB_BACKUP_PATH", r"%LOCALAPPDATA%\qBittorrent\BT_backup")))
 
 
 def qb_login(host: str, port: int, username: str, password: str) -> qbittorrentapi.Client:


### PR DESCRIPTION
1、不知道是不是我的情况特殊？IYUUPlus 自动辅种后状态是“paused”，而并不是 checkingDL、checkingUP。另外，为了方便区分自动辅种的种子，我在 IYUUPlus 里在任务设置里勾选了“标记标签”，因此我修改了规则，让程序只筛选出标签为“IYUU自动辅种”且状态为暂停的种子。

2、使用了 python-dotenv 库，支持将所需的环境变量写到 .env 文件里，这样就不用在批处理文件里写环境变量了。（另外 run.example.bat 我执行会报错，可能因为文件编码是 UTF-8）

3、修正文件夹变量扩展的一个bug